### PR TITLE
add session storage for caching note data on client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ webapp/react/.env.local
 webapp/react/public/env.js
 /.safenotes.*.yaml
 built/
-.safenotes.*.yaml
+.safenotes.*

--- a/webapp/react/src/SafeNotes/pages/NoteView/NoteView.js
+++ b/webapp/react/src/SafeNotes/pages/NoteView/NoteView.js
@@ -40,8 +40,8 @@ const NoteView = () => {
   useEffect(() => {
     storage
       .fetch(noteId)
-      .then(function (res) {
-        setLockedNote(res.data['content']);
+      .then(function (resource) {
+        setLockedNote(resource.payload);
       })
       .catch(function (err) {
         console.log(err);
@@ -51,7 +51,7 @@ const NoteView = () => {
 
   const onNoteUnlocked = (content) => {
     if (content === '') {
-      setUnlockedNote('Empty Note Contents Or The Passphrase Was Wrong!');
+      setUnlockedNote('The Passphrase Entered Was Wrong! Reload The Page And Try Again.');
       return;
     }
 
@@ -100,8 +100,8 @@ const NoteView = () => {
       <PinnedMessage>
         <Block classes={['flex', 'flex-col']}>
           <p className="text-sm sm:text-lg md:text-lg lg:text-lg font-bold">WARNING!</p>
-          <p className="text-xs sm:text-sm md:text-base lg:text-bas">Please make sure you save this note in a safe place before leaving or reloading the page.
-            <br/> Your secret has been <strong>DELETED</strong> from the storage and cannot be recovered!
+          <p className="text-xs sm:text-sm md:text-base lg:text-bas">Please make sure you save this note in a safe place before leaving the page.
+            <br/> Your secret has been <strong>DELETED</strong> from our storage and cannot be recovered!
           </p>
         </Block>
       </PinnedMessage>

--- a/webapp/react/src/lib/Cache.js
+++ b/webapp/react/src/lib/Cache.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020. Denis Rendler <connect@rendler.me>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default class Cache {
+    static #CACHE_KEY_PREFIX = "sn::";
+
+    fetch (key, defaultReturn) {
+       let keyName = Cache.#CACHE_KEY_PREFIX + key;
+       let itemData = window.sessionStorage.getItem(keyName);
+
+       if (null === itemData) {
+         return defaultReturn;
+       }
+
+       return JSON.parse(itemData);
+    }
+
+    store (key, payload) {
+      let keyName = Cache.#CACHE_KEY_PREFIX + key;
+
+      window.sessionStorage.setItem(keyName, JSON.stringify({
+          payload: payload
+      }));
+    }
+}
+

--- a/webapp/react/src/lib/StorageEngine.js
+++ b/webapp/react/src/lib/StorageEngine.js
@@ -14,48 +14,41 @@
  * limitations under the License.
  */
 
-import Axios from "axios";
-import Cache from "./Cache";
+import Axios from 'axios';
+import Cache from './Cache';
 
 class StorageEngine {
-    static #ROUTE_NOTES = "/notes";
+    static #ROUTE_NOTES = '/notes';
 
-    client = "";
-    cache = new Cache();
+    client = '';
+    cache  = new Cache();
 
-    constructor(storagePath) {
+    constructor (storagePath) {
         this.client = Axios.create({
             baseURL: storagePath,
             timeout: 1000,
-            headers: {"X-App": "SafeNotes"},
+            headers: { 'X-App': 'SafeNotes' },
         });
     }
 
-    store(params) {
+    store (params) {
         return this.client.post(StorageEngine.#ROUTE_NOTES, {}, {
             data: params,
         });
     }
 
-    fetch(path, params = {}) {
-        return new Promise((resolve, reject) => {
-            let cached = this.cache.fetch(path, false);
+    async fetch (path, params = {}) {
+        let cached = this.cache.fetch(path, false);
 
-            if (false === cached) {
-                this.client.get(StorageEngine.#ROUTE_NOTES + "/" + path, {...params})
-                    .then((response) => {
-                      this.cache.store(path, response.data['content']);
+        if (false === cached) {
+            await this.client.get(StorageEngine.#ROUTE_NOTES + '/' + path, { ...params })
+                .then((response) => {
+                    this.cache.store(path, response.data['content']);
+                })
+            ;
+        }
 
-                      resolve(this.cache.fetch(path, false));
-                    })
-                    .catch((err) => reject(err))
-                ;
-
-                return;
-            }
-
-            resolve(cached);
-        });
+        return this.cache.fetch(path, false);
     }
 }
 


### PR DESCRIPTION
- add cache library that uses browser's session storage
- update storage engine to use the cached version if one exists before
  requesting it from server
- update messages for end-user